### PR TITLE
one repl, many agents

### DIFF
--- a/src/is/simm/repl_mcp.clj
+++ b/src/is/simm/repl_mcp.clj
@@ -154,21 +154,34 @@
                           :nrepl-config {:port (:nrepl-port config)
                                         :ip "127.0.0.1"}
                           :server-info {:name "repl-mcp-simple" :version "1.0.0"}}
-          
           ;; Create instance directly - no complex lifecycle management
-          instance (server/create-mcp-server-instance! instance-config)]
-      
+          instance (server/create-mcp-server-instance! instance-config)
+          ;; Start HTTP server if transport is SSE
+          http-server (when (= (:transport config) :sse)
+                        (log/log! {:level :info :msg "Initializing SSE HTTP server" :data {:port (:http-port config)}})
+                        (let [mcp-context {:session (:session instance)
+                                           :nrepl-client (:nrepl-client instance)}]
+                          (sse/start-http-server! mcp-context (:http-port config))))]
+
+      (when http-server
+        (log/log! {:level :info :msg "HTTP+SSE server started"
+                   :data {:port (:http-port config) :url (str "http://127.0.0.1:" (:http-port config) "/sse")}}))
+
       ;; Store state for cleanup
       (reset! server-state {:nrepl-server nrepl-server
                            :instance instance
+                           :http-server http-server
                            :config config})
-      
+
       (log/log! {:level :info :msg "Simplified repl-mcp server started successfully" 
                  :data {:transport (:transport config)
                         :nrepl-port (:nrepl-port config)
-                        :tool-count (count (tools/get-tool-definitions))}})
-      
-      {:nrepl-server nrepl-server :instance instance})))
+                        :tool-count (count (tools/get-tool-definitions))
+                        :http-port (when http-server (:http-port config))}})
+
+      {:nrepl-server nrepl-server
+       :instance instance
+       :http-server http-server})))
 
 (defn stop-mcp-server!
   "Stop the simplified MCP server"
@@ -260,16 +273,8 @@
               :sse
               (do
                 (log/log! {:level :info :msg "SSE MCP server ready" :data {:http-port (:http-port options)}})
-                ;; Start HTTP+SSE server
-                (let [instance (:instance @server-state)
-                      mcp-context {:session (:session instance)
-                                   :nrepl-client (:nrepl-client instance)}
-                      http-server (sse/start-http-server! mcp-context (:http-port options))]
-                  (swap! server-state assoc :http-server http-server)
-                  (log/log! {:level :info :msg "HTTP+SSE server started" 
-                             :data {:port (:http-port options) :url (str "http://127.0.0.1:" (:http-port options) "/sse")}})
-                  ;; Keep the main thread alive
-                  @(promise)))))
+                ;; Keep the main thread alive - HTTP server started in start-mcp-server!
+                @(promise))))
           (catch Exception e
             (log/log! {:level :error :msg "Failed to start simplified server"
                        :data {:error (.getMessage e)}})

--- a/src/is/simm/repl_mcp.clj
+++ b/src/is/simm/repl_mcp.clj
@@ -159,9 +159,10 @@
           ;; Start HTTP server if transport is SSE
           http-server (when (= (:transport config) :sse)
                         (log/log! {:level :info :msg "Initializing SSE HTTP server" :data {:port (:http-port config)}})
-                        (let [mcp-context {:session (:session instance)
-                                           :nrepl-client (:nrepl-client instance)}]
-                          (sse/start-http-server! mcp-context (:http-port config))))]
+                        (let [context-factory (fn []
+                                                (log/log! {:level :info :msg "Creating new session for SSE connection"})
+                                                (:context (server/create-mcp-server-instance! instance-config)))]
+                          (sse/start-http-server! context-factory (:http-port config))))]
 
       (when http-server
         (log/log! {:level :info :msg "HTTP+SSE server started"

--- a/test/is/simm/repl_mcp/integration/sse_direct_test.clj
+++ b/test/is/simm/repl_mcp/integration/sse_direct_test.clj
@@ -11,14 +11,15 @@
   (testing "Direct server creation and HTTP test"
     
     ;; Create server instance without nREPL dependency
-    (let [instance (server/create-mcp-server-instance!
-                    {:tools (tools/get-tool-definitions)
-                     :server-info {:name "direct-sse-server" :version "1.0.0"}})
-          mcp-context {:session (:session instance)
-                       :nrepl-client nil} ; No nREPL for this test
+    (let [context-factory (fn []
+                           (let [instance (server/create-mcp-server-instance!
+                                           {:tools (tools/get-tool-definitions)
+                                            :server-info {:name "direct-sse-server" :version "1.0.0"}})]
+                             {:session (:session instance)
+                              :nrepl-client nil})) ; No nREPL for this test
           test-port 18491]
       
-      (let [http-server (sse/start-http-server! mcp-context test-port)]
+      (let [http-server (sse/start-http-server! context-factory test-port)]
         
         (try
           (Thread/sleep 2000)


### PR DESCRIPTION
This PR introduces multi-session support for SSE connections, adds a heartbeat mechanism to keep connections alive, and refactors the server startup to better handle the HTTP server lifecycle.

  Key Changes

  1. Include HTTP server in `start-mcp-server!` for use outside main
   - Integrated Startup: start-mcp-server! in repl_mcp.clj now initializes the HTTP server directly when the transport is set to :sse.
   - Return Value: The http-server instance is now returned as part of the system map, allowing for better control and inspection outside of the main entry point.
   - Cleanup: stop-mcp-server! correctly shuts down the HTTP server and the heartbeat loop.

  2. Multi-Session Support
   - Context Factory: start-http-server! in sse.clj now accepts a context-factory function instead of a static mcp-context.
   - Per-Connection Instance: Each incoming SSE connection triggers the creation of a new MCP server instance via the factory. This ensures that state is isolated between different
     clients/sessions.
   - Implementation: Updated handle-sse-stream to invoke the factory for every new connection.
   - sessions are currently anonymous and only identifiable by session-id

  3. SSE Heartbeat Mechanism
   - Keep-Alive: Implemented a background loop that sends a ping event to all active SSE connections every 15 seconds.
   - Stability: This prevents intermediate proxies or clients from closing the connection due to inactivity.
   - Lifecycle: The heartbeat loop starts and stops automatically with the HTTP server.

  Commits
   - include http-server in start-mcp-server! for use outside main
   - anonymous multi-session support
   - heartbeat